### PR TITLE
Use borrow trait to add items into sketch

### DIFF
--- a/src/hyperloglog.rs
+++ b/src/hyperloglog.rs
@@ -1,6 +1,8 @@
 use core::hash::{BuildHasher, Hash, Hasher};
 use core::marker::PhantomData;
 
+use std::borrow::Borrow;
+
 use serde::{Deserialize, Serialize};
 
 use crate::common::*;
@@ -25,7 +27,7 @@ use crate::HyperLogLogError;
 /// use std::collections::hash_map::RandomState;
 /// use hyperloglogplus::{HyperLogLog, HyperLogLogPF};
 ///
-/// let mut hll = HyperLogLogPF::new(16, RandomState::new()).unwrap();
+/// let mut hll = HyperLogLogPF::<u64, _>::new(16, RandomState::new()).unwrap();
 ///
 /// hll.add(&12345);
 /// hll.add(&23456);
@@ -127,7 +129,11 @@ where
     B: BuildHasher,
 {
     /// Adds a new value to the multiset.
-    fn add(&mut self, value: &H) {
+    fn add<Q>(&mut self, value: &Q)
+    where
+        H: Borrow<Q>,
+        Q: Hash + ?Sized,
+    {
         // Create a new hasher.
         let mut hasher = self.builder.build_hasher();
         // Calculate the hash.

--- a/src/hyperloglogplus.rs
+++ b/src/hyperloglogplus.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::collections::HashSet;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::marker::PhantomData;
@@ -31,10 +32,10 @@ use crate::HyperLogLogError;
 /// use std::collections::hash_map::RandomState;
 /// use hyperloglogplus::{HyperLogLog, HyperLogLogPlus};
 ///
-/// let mut hllp = HyperLogLogPlus::new(16, RandomState::new()).unwrap();
+/// let mut hllp = HyperLogLogPlus::<u64, _>::new(16, RandomState::new()).unwrap();
 ///
-/// hllp.add(&12345);
-/// hllp.add(&23456);
+/// hllp.add(&12345u64);
+/// hllp.add(&23456u64);
 ///
 /// assert_eq!(hllp.count().trunc() as u32, 2);
 /// ```
@@ -398,7 +399,11 @@ where
     B: BuildHasher,
 {
     /// Adds a new value to the multiset.
-    fn add(&mut self, value: &H) {
+    fn add<Q>(&mut self, value: &Q)
+    where
+        H: Borrow<Q>,
+        Q: Hash + ?Sized,
+    {
         // Create a new hasher.
         let mut hasher = self.builder.build_hasher();
         // Calculate the hash.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,8 @@ mod log;
 use core::fmt;
 use core::hash::Hash;
 
+use std::borrow::Borrow;
+
 // Available also with no_std.
 pub use crate::hyperloglog::HyperLogLogPF;
 
@@ -44,7 +46,10 @@ pub use crate::hyperloglogplus::HyperLogLogPlus;
 /// A trait that should be implemented by any HyperLogLog variant.
 pub trait HyperLogLog<H: Hash + ?Sized> {
     /// Adds a new value to the multiset.
-    fn add(&mut self, value: &H);
+    fn add<Q>(&mut self, value: &Q)
+        where
+            H: Borrow<Q>,
+            Q: Hash + ?Sized;
     /// Estimates the cardinality of the multiset.
     fn count(&mut self) -> f64;
 }


### PR DESCRIPTION
Using the borrow trait when inserting a value into the sketch, i.e. `value: &Q` with `H: Borrow<Q>` rather than `value: &H`, makes the sketch types much more flexible. For example, you don't run into the issue of having a type that contains a lifetime in the sketch: `struct HyperLogLog<H>` with `H = MyType<'a>` causes issues when `MyType<'a>` is a temporary value that references a type that's being destroyed at the end of some scope.

I ran into the issue where I don't insert “owned” items into the sketch, but something like `MyType<'a>` instead, and I quickly ran into trouble with the thing that `MyType` was referencing being destroyed. That's because `HyperLogLog<MyType<'a>>` extended the lifetime of `'a` to that of `HyperLogLog` which wasn't workable.

This basically follows the same design as `HashMap`.